### PR TITLE
A slightly messy PR

### DIFF
--- a/.rapunzel.yaml
+++ b/.rapunzel.yaml
@@ -1,4 +1,4 @@
 run: |
-  !pandoc website.md --css="stylesheet.css" --standalone --self-contained -o index.html
+  !pandoc website.md --template=template.html --css=stylesheet.css --standalone --self-contained -o index.html
   import webbrowser
   webbrowser.open('index.html')

--- a/convert.sh
+++ b/convert.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-pandoc website.md --css="stylesheet.css" --standalone --self-contained -o index.html
+pandoc website.md --template=template.html --css="stylesheet.css" --standalone --self-contained -o index.html

--- a/jatos-home/jatos-home.html
+++ b/jatos-home/jatos-home.html
@@ -1,0 +1,13 @@
+<div style="text-align: center;">
+    <p>
+    <img src="https://raw.githubusercontent.com/lindenloot/MindProbe-docs/master/img/mindprobe-logo.png">
+    </p>
+    <h2>Hi @USER_NAME!</h2>
+    <p>Welcome to MindProbe, a free server for hosting online experiments</p>
+    <p><small>Powered by JATOS @JATOS_VERSION.<br />Sponsored by the European Society for Cognitive Psychology (ESCoP) and OpenSesame.</small></p>
+    <p>
+        <a href="https://www.jatos.org/Whats-JATOS.html" class="btn btn-default" role="button" target="_blank">JATOS docs &raquo;</a>
+        <a href="https://osdoc.cogsci.nl/" class="btn btn-default" role="button" target="_blank">OpenSesame / OSWeb docs &raquo;</a>
+        <a href="https://www.journalofcognition.org/" class="btn btn-default" role="button" target="_blank">Journal of Cognition (official ESCoP journal) &raquo;</a>
+    </p>
+</div>

--- a/template.html
+++ b/template.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$lang$" xml:lang="$lang$"$if(dir)$ dir="$dir$"$endif$>
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+    $for(css)$
+      <link rel="stylesheet" href="$css$" />
+    $endfor$  
+  <title>MindProbe</title>
+</head>
+<body>
+$body$
+</body>
+</html>


### PR DESCRIPTION
I added a template HTML. This is convenient because it gives a bit more control when pandoc generates an html file based on markdown. I also added an example (to be customized further, I think) that Kristian can use to embed in the JATOS home page.